### PR TITLE
 [db_migrator] Upgrade policer attached to the mirror sessions to include color=blind

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -44,7 +44,7 @@ class DBMigrator():
                      none-zero values.
               build: sequentially increase within a minor version domain.
         """
-        self.CURRENT_VERSION = 'version_3_0_5'
+        self.CURRENT_VERSION = 'version_3_0_6'
 
         self.TABLE_NAME      = 'VERSIONS'
         self.TABLE_KEY       = 'DATABASE'
@@ -729,9 +729,16 @@ class DBMigrator():
             policers = [v['policer'] for k, v in mirror_sess.items() if 'policer' in v]
             for policer in policers:
                 data = self.configDB.get_entry('POLICER', policer)
-                if data.get('color') != 'blind':
+                if data.get('color') == 'aware':
                     data.update({'color': 'blind'})
                     self.configDB.set_entry('POLICER', policer, data)
+        return 'version_3_0_6'
+
+    def version_3_0_6(self):
+        """
+        Current latest version. Nothing to do here.
+        """
+        log.log_info('Handling version_3_0_6')
         return None
 
     def get_version(self):

--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -722,14 +722,14 @@ class DBMigrator():
         log.log_info('Handling version_3_0_5')
         # If the policer used for mirror_session happen to have color set as aware
         # Change the color to blind. This is support the new enhancement made for Mellanox platforms.
-        # If the user mistakenly sets color as aware up until this image,
-        # this'll lead to orchagent crash after the upgrade
+        # If the user did not set color as blind up until this image,
+        # that'll lead to orchagent crash after the upgrade
         if self.asic_type == 'mellanox':
             mirror_sess = self.configDB.get_table('MIRROR_SESSION')
             policers = [v['policer'] for k, v in mirror_sess.items() if 'policer' in v]
             for policer in policers:
                 data = self.configDB.get_entry('POLICER', policer)
-                if data.get('color') == 'aware':
+                if data.get('color') != 'blind':
                     data.update({'color': 'blind'})
                     self.configDB.set_entry('POLICER', policer, data)
         return 'version_3_0_6'

--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -717,9 +717,21 @@ class DBMigrator():
 
     def version_3_0_5(self):
         """
-        Current latest version. Nothing to do here.
+        Version 3_0_5
         """
         log.log_info('Handling version_3_0_5')
+        # If the policer used for mirror_session happen to have color set as aware
+        # Change the color to blind. This is support the new enhancement made for Mellanox platforms.
+        # If the user mistakenly sets color as aware up until this image,
+        # this'll lead to orchagent crash after the upgrade
+        if self.asic_type == 'mellanox':
+            mirror_sess = self.configDB.get_table('MIRROR_SESSION')
+            policers = [v['policer'] for k, v in mirror_sess.items() if 'policer' in v]
+            for policer in policers:
+                data = self.configDB.get_entry('POLICER', policer)
+                if data.get('color') != 'blind':
+                    data.update({'color': 'blind'})
+                    self.configDB.set_entry('POLICER', policer, data)
         return None
 
     def get_version(self):

--- a/tests/db_migrator_input/config_db/mirror_policer_cfg.json
+++ b/tests/db_migrator_input/config_db/mirror_policer_cfg.json
@@ -31,5 +31,20 @@
         "cbs": "12500000",
         "color": "aware",
         "red_packet_action": "drop"
+    },
+    "MIRROR_SESSION|mirror_session_src_ip": {
+        "dscp": "5",
+        "dst_ip": "1.1.1.1",
+        "policer": "policer_src_ip",
+        "src_ip": "2.2.2.2",
+        "ttl": "32",
+        "type": "ERSPAN"
+    },
+    "POLICER|policer_src_ip": {
+        "meter_type": "bytes",
+        "mode": "sr_tcm",
+        "cir": "12500000",
+        "cbs": "12500000",
+        "red_packet_action": "drop"
     }
 }

--- a/tests/db_migrator_input/config_db/mirror_policer_cfg.json
+++ b/tests/db_migrator_input/config_db/mirror_policer_cfg.json
@@ -1,0 +1,35 @@
+{
+    "VERSIONS|DATABASE": {
+        "VERSION": "version_3_0_4"
+    },
+    "ACL_TABLE|EVERFLOW_DSCP": {
+            "stage": "ingress", 
+            "type": "MIRROR_DSCP",  
+            "ports@": "Ethernet0",
+            "policy_desc": "EVERFLOW_DSCP"
+    },
+    "MIRROR_SESSION|mirror_session_dscp": {
+        "dscp": "5",
+        "dst_ip": "1.1.1.1",
+        "policer": "policer_dscp",
+        "src_ip": "2.2.2.2",
+        "ttl": "32",
+        "type": "ERSPAN"
+    },
+    "POLICER|policer_dscp": {
+        "meter_type": "bytes",
+        "mode": "sr_tcm",
+        "cir": "12500000",
+        "cbs": "12500000",
+        "color": "aware",
+        "red_packet_action": "drop"
+    },
+    "POLICER|policer_random": {
+        "meter_type": "bytes",
+        "mode": "sr_tcm",
+        "cir": "12500000",
+        "cbs": "12500000",
+        "color": "aware",
+        "red_packet_action": "drop"
+    }
+}

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -428,7 +428,7 @@ class TestMirrorPolicerColorMigrate(object):
         dbmgtr_mlnx.migrate()
         assert dbmgtr_mlnx.configDB.get_entry('POLICER', 'policer_dscp').get('color') == 'blind'
         assert dbmgtr_mlnx.configDB.get_entry('POLICER', 'policer_random').get('color') == 'aware'
-        assert not dbmgtr_mlnx.configDB.get_entry('POLICER', 'policer_src_ip').get('color')
+        assert dbmgtr_mlnx.configDB.get_entry('POLICER', 'policer_src_ip').get('color') == 'blind'
 
         dbmgtr = db_migrator.DBMigrator(None)
         dbmgtr.asic_type = "broadcom"
@@ -436,4 +436,4 @@ class TestMirrorPolicerColorMigrate(object):
         dbmgtr.migrate()
         assert dbmgtr.configDB.get_entry('POLICER', 'policer_dscp').get('color') == 'aware'
         assert dbmgtr.configDB.get_entry('POLICER', 'policer_random').get('color') == 'aware'
-        assert not dbmgtr_mlnx.configDB.get_entry('POLICER', 'policer_src_ip').get('color')
+        assert not dbmgtr.configDB.get_entry('POLICER', 'policer_src_ip').get('color')

--- a/tests/db_migrator_test.py
+++ b/tests/db_migrator_test.py
@@ -428,6 +428,7 @@ class TestMirrorPolicerColorMigrate(object):
         dbmgtr_mlnx.migrate()
         assert dbmgtr_mlnx.configDB.get_entry('POLICER', 'policer_dscp').get('color') == 'blind'
         assert dbmgtr_mlnx.configDB.get_entry('POLICER', 'policer_random').get('color') == 'aware'
+        assert not dbmgtr_mlnx.configDB.get_entry('POLICER', 'policer_src_ip').get('color')
 
         dbmgtr = db_migrator.DBMigrator(None)
         dbmgtr.asic_type = "broadcom"
@@ -435,3 +436,4 @@ class TestMirrorPolicerColorMigrate(object):
         dbmgtr.migrate()
         assert dbmgtr.configDB.get_entry('POLICER', 'policer_dscp').get('color') == 'aware'
         assert dbmgtr.configDB.get_entry('POLICER', 'policer_random').get('color') == 'aware'
+        assert not dbmgtr_mlnx.configDB.get_entry('POLICER', 'policer_src_ip').get('color')


### PR DESCRIPTION
Signed-off-by: Vivek Reddy Karri <vkarri@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

