### PR TITLE
[app_ext] [auto-ts] Add available_mem_threshold option

### DIFF
--- a/sonic_package_manager/service_creator/feature.py
+++ b/sonic_package_manager/service_creator/feature.py
@@ -19,10 +19,10 @@ DEFAULT_FEATURE_CONFIG = {
 AUTO_TS_GLOBAL = "AUTO_TECHSUPPORT"
 AUTO_TS_FEATURE = "AUTO_TECHSUPPORT_FEATURE"
 CFG_STATE = "state"
-# TODO: Enable available_mem_threshold once the mem_leak_auto_ts feature is available
 DEFAULT_AUTO_TS_FEATURE_CONFIG = {
     'state': 'disabled',
-    'rate_limit_interval': '600'
+    'rate_limit_interval': '600',
+    'available_mem_threshold': '10.0'
 }
 
 def is_enabled(cfg):

--- a/tests/sonic_package_manager/test_service_creator.py
+++ b/tests/sonic_package_manager/test_service_creator.py
@@ -313,7 +313,7 @@ class AutoTSHelp:
     @classmethod
     def get_entry_running_cfg(cls, table, key):
         if table == "AUTO_TECHSUPPORT_FEATURE" and key == "test":
-            return {"state" : "disabled", "rate_limit_interval" : "1000"}
+            return {"state" : "disabled", "rate_limit_interval" : "1000", "available_mem_threshold": "20.0"}
         else:
             return {}
 
@@ -328,7 +328,8 @@ def test_auto_ts_global_disabled(mock_sonic_db, manifest):
     feature_registry.register(manifest)
     mock_init_cfg.set_entry.assert_any_call("AUTO_TECHSUPPORT_FEATURE", "test", {
             "state" : "disabled",
-            "rate_limit_interval" : "600"
+            "rate_limit_interval" : "600",
+            "available_mem_threshold": "10.0"
         }
     )
 
@@ -343,7 +344,8 @@ def test_auto_ts_global_enabled(mock_sonic_db, manifest):
     feature_registry.register(manifest)
     mock_init_cfg.set_entry.assert_any_call("AUTO_TECHSUPPORT_FEATURE", "test", {
             "state" : "enabled",
-            "rate_limit_interval" : "600"
+            "rate_limit_interval" : "600",
+            "available_mem_threshold": "10.0"
         }
     )
 
@@ -382,7 +384,8 @@ def test_auto_ts_feature_update_flow(mock_sonic_db, manifest):
             call("AUTO_TECHSUPPORT_FEATURE", "test", None),
             call("AUTO_TECHSUPPORT_FEATURE", "test_new", {
                     "state" : "enabled",
-                    "rate_limit_interval" : "600"
+                    "rate_limit_interval" : "600",
+                    "available_mem_threshold": "10.0"
                 })
         ],
         any_order = True
@@ -393,7 +396,8 @@ def test_auto_ts_feature_update_flow(mock_sonic_db, manifest):
             call("AUTO_TECHSUPPORT_FEATURE", "test", None),
             call("AUTO_TECHSUPPORT_FEATURE", "test_new", {
                     "state" : "disabled",
-                    "rate_limit_interval" : "1000"
+                    "rate_limit_interval" : "1000",
+                    "available_mem_threshold": "20.0"
                 })
         ],
         any_order = True


### PR DESCRIPTION
Signed-off-by: Vivek Reddy Karri <vkarri@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

With this change, when a new app-extension is installed, available_mem_threshold config is added to `AUTO_TECHSUPPORT_FEATURE|<feature_name>` key 

#### How I did it

#### How to verify it

```
vkarri@d7a060369aba:/sonic/src/sonic-utilities$ pytest-3 tests/sonic_package_manager/test_service_creator.py 
=============================================================== test session starts ===============================================================
platform linux -- Python 3.9.2, pytest-6.0.2, py-1.10.0, pluggy-0.13.0
rootdir: /sonic/src/sonic-utilities/tests, configfile: pytest.ini
plugins: pyfakefs-4.7.0, cov-2.10.1
collected 13 items                                                                                                                                

tests/sonic_package_manager/test_service_creator.py .............                                                                           [100%]

=============================================================== 13 passed in 0.25s ================================================================
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

