### PR TITLE
[db_migrator] Fix the broken version chain

### DIFF
--- a/scripts/db_migrator.py
+++ b/scripts/db_migrator.py
@@ -984,10 +984,19 @@ class DBMigrator():
     def version_3_0_6(self):
         """
         Version 3_0_6
-        This is the latest version for 202211 branch
         """
 
         log.log_info('Handling version_3_0_6')
+        self.set_version('version_3_0_7')
+        return 'version_3_0_7'
+
+    def version_3_0_7(self):
+        """
+        Version 3_0_7
+        This is the latest version for 202205 branch
+        """
+
+        log.log_info('Handling version_3_0_7')
         self.set_version('version_4_0_0')
         return 'version_4_0_0'
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### Why I did

Warm Reboot from 202205 -> latest labels is failing because of an extra version that was added to 202205 and that was missing in later branches.

#### How I did it

Add a placeholder for version 3_0_7 in latest labels

#### How to verify it

WR from 202205 to 202305 and try running db_migrator

```
root@r-anaconda-simx-139:/home/admin# db_migrator.py -o migrate
Traceback (most recent call last):
  File "/usr/local/bin/db_migrator.py", line 1133, in main
    result = getattr(dbmgtr, operation)()
  File "/usr/local/bin/db_migrator.py", line 1085, in migrate
    next_version = getattr(self, version)()
AttributeError: 'DBMigrator' object has no attribute 'version_3_0_7'
'DBMigrator' object has no attribute 'version_3_0_7'
usage: db_migrator.py [-h] [-o operation migrate, set_version, get_version] [-s unix socket] [-n asic namespace]

optional arguments:
  -h, --help            show this help message and exit
  -o operation (migrate, set_version, get_version)
                        operation to perform [default: get_version]
  -s unix socket        the unix socket that the desired database listens on
  -n asic namespace     The asic namespace whose DB instance we need to connect
```

With this change:
```

root@r-anaconda-simx-139:/home/admin# db_migrator.py -o migrate
root@r-anaconda-simx-139:/home/admin# redis-cli -n 4 hgetall "VERSIONS|DATABASE"
1) "VERSION"
2) "version_4_0_3"
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

