### PR TITLE
Fix soft-reboot to support secure boot enabled platforms

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -673,7 +673,7 @@ if is_secureboot && grep -q aboot_machine= /host/machine.conf; then
 else
     # check if secure boot is enable in UEFI
     CHECK_SECURE_UPGRADE_ENABLED=0
-    SECURE_UPGRADE_ENABLED=$(bootctl status 2>/dev/null | grep -c "Secure Boot: enabled") || CHECK_SECURE_UPGRADE_ENABLED=$?
+    SECURE_UPGRADE_ENABLED=$(mokutil --sb-state 2>/dev/null | grep -c "enabled") || CHECK_SECURE_UPGRADE_ENABLED=$?
     if [[ CHECK_SECURE_UPGRADE_ENABLED -ne 0 ]]; then
         debug "Loading kernel without secure boot"
         load_kernel

--- a/scripts/soft-reboot
+++ b/scripts/soft-reboot
@@ -93,7 +93,7 @@ function clear_lingering_reboot_config()
     if [[ -f ${WARM_DIR}/${REDIS_FILE} ]]; then
         mv -f ${WARM_DIR}/${REDIS_FILE} ${WARM_DIR}/${REDIS_FILE}.${TIMESTAMP} || /bin/true
     fi
-    /sbin/kexec -u || /bin/true
+    /sbin/kexec -u -a || /bin/true
 }
 
 SCRIPT=$0
@@ -147,9 +147,17 @@ function setup_reboot_variables()
     fi
 }
 
+function invoke_kexec() {
+    /sbin/kexec -l "$KERNEL_IMAGE" --initrd="$INITRD" --append="$BOOT_OPTIONS" $@
+}
+
 function load_kernel() {
     # Load kernel into the memory
-    /sbin/kexec -l "$KERNEL_IMAGE" --initrd="$INITRD" --append="$BOOT_OPTIONS"
+    invoke_kexec -a
+}
+
+function load_kernel_secure() {
+    invoke_kexec -s
 }
 
 function reboot_pre_check()
@@ -215,7 +223,14 @@ stop_sonic_services
 
 clear_lingering_reboot_config
 
-load_kernel
+# check if secure boot is enabled 
+CHECK_SECURE_UPGRADE_ENABLED=0
+SECURE_UPGRADE_ENABLED=$(mokutil --sb-state 2>/dev/null | grep -c "enabled") || CHECK_SECURE_UPGRADE_ENABLED=$?
+if [[ CHECK_SECURE_UPGRADE_ENABLED -ne 0 ]]; then
+    load_kernel
+else
+    load_kernel_secure
+fi
 
 # Update the reboot cause file to reflect that user issued 'reboot' command
 # Upon next boot, the contents of this file will be used to determine the


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

1) soft-reboot is failing on platforms with Secure boot enabled

```
root@sn-5400:/home/admin# soft-reboot
kexec unload failed: Permission denied
kexec_load failed: Permission denied
entry       = 0x86eff7760 flags = 0x3e0000
nr_segments = 7
segment[0].buf   = 0x556cb2a1ad30
segment[0].bufsz = 0x70
segment[0].mem   = 0x100000
segment[0].memsz = 0x1000
segment[1].buf   = 0x556cb2a22d70
segment[1].bufsz = 0x168
segment[1].mem   = 0x101000
segment[1].memsz = 0x1000
segment[2].buf   = 0x556cb2a1b320
segment[2].bufsz = 0x30
segment[2].mem   = 0x102000
segment[2].memsz = 0x1000
segment[3].buf   = 0x7f0b3655e010
segment[3].bufsz = 0x1fcf164
segment[3].mem   = 0x868c30000
segment[3].memsz = 0x1fd0000
segment[4].buf   = 0x7f0b38532210
segment[4].bufsz = 0x7b7418
segment[4].mem   = 0x86ac00000
segment[4].memsz = 0x438c000
segment[5].buf   = 0x556cb2a151c0
segment[5].bufsz = 0x4422
segment[5].mem   = 0x86eff2000
segment[5].memsz = 0x5000
segment[6].buf   = 0x556cb2a0df10
segment[6].bufsz = 0x70e0
segment[6].mem   = 0x86eff7000
segment[6].memsz = 0x9000
Watchdog armed for 180 seconds
Nothing has been loaded!
```

2) Use mokutil instead of bootctl as bootctl is not installed in Bookworm 

#### How I did it

#### How to verify it

After fixing the scripts

```
root@sn5600:/home/admin# soft-reboot
+ SECURE_UPGRADE_ENABLED=1
+ [[ CHECK_SECURE_UPGRADE_ENABLED -ne 0 ]]
+ load_kernel_secure
+ invoke_kexec -s
packet_write_wait: port 22: Broken pipe

admin@sn5600:~$ show reboot-cause
User issued 'soft-reboot' command [User: admin, Time: Tue Jul 23 11:06:43 PM UTC 2024]
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

