### PR TITLE
Upgrade pyroute2 and improve cli response time

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -249,7 +249,7 @@ setup(
         'pexpect>=4.8.0',
         'semantic-version>=2.8.5',
         'prettyprinter>=0.18.0',
-        'pyroute2>=0.5.14, <0.6.1',
+        'pyroute2==0.7.12',
         'requests>=2.25.0, <=2.31.0',
         'tabulate==0.9.0',
         'toposort==1.6',

--- a/utilities_common/multi_asic.py
+++ b/utilities_common/multi_asic.py
@@ -3,7 +3,6 @@ import functools
 
 import click
 import netifaces
-import pyroute2
 from natsort import natsorted
 from sonic_py_common import multi_asic, device_info
 from utilities_common import constants
@@ -170,6 +169,7 @@ def multi_asic_args(parser=None):
     return parser
 
 def multi_asic_get_ip_intf_from_ns(namespace):
+    import pyroute2
     if namespace != constants.DEFAULT_NAMESPACE:
         pyroute2.netns.pushns(namespace)
     interfaces = natsorted(netifaces.interfaces())
@@ -181,6 +181,7 @@ def multi_asic_get_ip_intf_from_ns(namespace):
 
 
 def multi_asic_get_ip_intf_addr_from_ns(namespace, iface):
+    import pyroute2
     if namespace != constants.DEFAULT_NAMESPACE:
         pyroute2.netns.pushns(namespace)
     ipaddresses = netifaces.ifaddresses(iface)


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

- Older pyroute2 depends on distutils. Thus upgrade the version to latest to improve import time. A similar issue for natsort is reported here `https://github.com/sonic-net/sonic-buildimage/issues/17246`. However pyroute2 import is still heavy in bookworm and thus every CLI command is slow compared to bullseye. 

```
<Bullseye>
root@msn2700:/home/admin# time python3 -c "import pyroute2"
real	0m0.378s
user	0m0.308s
sys	0m0.060s

<Before upgrade>
root@msn2700:/home/admin# time python3 -c "import pyroute2"
real        0m0.707s
user        0m0.425s
sys        0m0.097s

<After upgrade>
root@msn2700:/home/admin#  time python3 -c "import pyroute2"
real	0m0.511s
user	0m0.433s
sys	0m0.075s
```

- To fix this, i've delayed the pyroute2 import into the method where it is actually used, this has an improvement of 0.4 sec for all the CLI commands on slower CPU devices

```
root@msn2700:/home/admin#  time python3 -c "import utilities_common.cli as clicommon"
real	0m0.693s
user	0m0.579s
sys	0m0.109s

root@msn2700/home/admin#  time python3 -c "import utilities_common.cli as clicommon"
real	0m0.363s
user	0m0.271s
sys	0m0.072s
```


#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

