### PR TITLE
[ACL] Display rule and table info written to APP DB

### DIFF
--- a/acl_loader/main.py
+++ b/acl_loader/main.py
@@ -73,8 +73,10 @@ class AclLoader(object):
     ACL_TABLE = "ACL_TABLE"
     ACL_RULE = "ACL_RULE"
     CFG_ACL_TABLE = "ACL_TABLE"
+    APPL_ACL_TABLE = "ACL_TABLE_TABLE"
     STATE_ACL_TABLE = "ACL_TABLE_TABLE"
     CFG_ACL_RULE = "ACL_RULE"
+    APPL_ACL_RULE = "ACL_RULE_TABLE"
     STATE_ACL_RULE = "ACL_RULE_TABLE"
     ACL_TABLE_TYPE_MIRROR = "MIRROR"
     ACL_TABLE_TYPE_CTRLPLANE = "CTRLPLANE"
@@ -135,6 +137,8 @@ class AclLoader(object):
         self.configdb.connect()
         self.statedb = SonicV2Connector(host="127.0.0.1")
         self.statedb.connect(self.statedb.STATE_DB)
+        self.appldb = SonicV2Connector(host="127.0.0.1")
+        self.appldb.connect(self.statedb.APPL_DB)
 
         # For multi-npu architecture we will have both global and per front asic namespace.
         # Global namespace will be used for Control plane ACL which are via IPTables.
@@ -165,8 +169,8 @@ class AclLoader(object):
         self.read_rules_info()
         self.read_sessions_info()
         self.read_policers_info()
-        self.acl_table_status = self.read_acl_object_status_info(self.CFG_ACL_TABLE, self.STATE_ACL_TABLE)
-        self.acl_rule_status = self.read_acl_object_status_info(self.CFG_ACL_RULE, self.STATE_ACL_RULE)
+        self.acl_table_status = self.read_acl_object_status_info(self.tables_db_info.keys(), self.STATE_ACL_TABLE)
+        self.acl_rule_status = self.read_acl_object_status_info(self.rules_db_info.keys(), self.STATE_ACL_RULE)
 
     def read_tables_info(self):
         """
@@ -199,15 +203,50 @@ class AclLoader(object):
                         self.tables_db_info[table]['ports'] += entry.get(
                             'ports', [])
 
+        if self.per_npu_configdb:
+            # Note: Ability to read table information from APPL_DB is not yet supported for masic devices
+            return
+
+        appl_db_keys = self.appldb.keys(self.appldb.APPL_DB, "{}:*".format(self.APPL_ACL_TABLE))
+        if not appl_db_keys:
+            return  
+
+        for app_acl_tbl in appl_db_keys:
+            key = app_acl_tbl.split(":")[-1]
+            if key in self.tables_db_info:
+                # Shouldn't be hit, table is either programmed to APPL or CONFIG DB
+                continue
+            self.tables_db_info[key] = dict()
+            for f, v in self.appldb.get_all(self.appldb.APPL_DB, app_acl_tbl).items():
+                if f.lower() == "ports":
+                    v = v.split(",")
+                self.tables_db_info[key][f.lower()] = v
+
     def get_tables_db_info(self):
         return self.tables_db_info
 
     def read_rules_info(self):
         """
-        Read ACL_RULE table from configuration database
+        Read ACL_RULE table from CFG_DB and APPL_DB database
         :return:
         """
         self.rules_db_info = self.configdb.get_table(self.ACL_RULE)
+
+        if self.per_npu_configdb:
+            # Note: Ability to read table information from APPL_DB is not yet supported for masic devices
+            return
+
+        # Read rule information from APPL_DB
+        appl_db_keys = self.appldb.keys(self.appldb.APPL_DB, "{}:*".format(self.APPL_ACL_RULE))
+        if not appl_db_keys:
+            return
+
+        for app_acl_rule in appl_db_keys:
+            _, tid, rid = app_acl_rule.split(":")
+            if (tid, rid) in self.rules_db_info:
+                # Shouldn't be hit, table is either programmed to APPL or CONFIG DB
+                continue
+            self.rules_db_info[(tid, rid)] = self.appldb.get_all(self.appldb.APPL_DB, app_acl_rule)
 
     def get_rules_db_info(self):
         return self.rules_db_info
@@ -259,16 +298,10 @@ class AclLoader(object):
                 self.sessions_db_info[key]["status"] = state_db_info.get("status", "inactive") if state_db_info else "error"
                 self.sessions_db_info[key]["monitor_port"] = state_db_info.get("monitor_port", "") if state_db_info else ""
 
-    def read_acl_object_status_info(self, cfg_db_table_name, state_db_table_name):
+    def read_acl_object_status_info(self, keys, state_db_table_name):
         """
         Read ACL_TABLE status or ACL_RULE status from STATE_DB
         """
-        if self.per_npu_configdb:
-            namespace_configdb = list(self.per_npu_configdb.values())[0]
-            keys = namespace_configdb.get_table(cfg_db_table_name).keys()
-        else:
-            keys = self.configdb.get_table(cfg_db_table_name).keys()
-
         status = {}
         for key in keys:
             # For ACL_RULE, the key is (acl_table_name, acl_rule_name)
@@ -922,19 +955,19 @@ class AclLoader(object):
                 status = self.acl_table_status[key]['status']
             else:
                 status = 'N/A'
-            if val["type"] == AclLoader.ACL_TABLE_TYPE_CTRLPLANE:
+            if val.get("type", "N/A") == AclLoader.ACL_TABLE_TYPE_CTRLPLANE:
                 services = natsorted(val["services"])
-                data.append([key, val["type"], services[0], val["policy_desc"], stage, status])
+                data.append([key, val.get("type", "N/A"), services[0], val.get("policy_desc", ""), stage, status])
 
                 if len(services) > 1:
                     for service in services[1:]:
                         data.append(["", "", service, "", "", ""])
             else:
-                if not val["ports"]:
-                    data.append([key, val["type"], "", val["policy_desc"], stage, status])
+                if not val.get("ports", []):
+                    data.append([key, val["type"], "", val.get("policy_desc", ""), stage, status])
                 else:
                     ports = natsorted(val["ports"])
-                    data.append([key, val["type"], ports[0], val["policy_desc"], stage, status])
+                    data.append([key, val["type"], ports[0], val.get("policy_desc", ""), stage, status])
 
                     if len(ports) > 1:
                         for port in ports[1:]:

--- a/dump/plugins/acl_rule.py
+++ b/dump/plugins/acl_rule.py
@@ -8,6 +8,8 @@ from .executor import Executor
 
 CFG_DB_SEPARATOR = SonicDBConfig.getSeparator("CONFIG_DB")
 ASIC_DB_SEPARATOR = SonicDBConfig.getSeparator("ASIC_DB")
+APP_DB_SEPARATOR = SonicDBConfig.getSeparator("APPL_DB")
+APP_RULE_NAME = "ACL_RULE_TABLE"
 
 
 class Acl_Rule(Executor):
@@ -22,19 +24,28 @@ class Acl_Rule(Executor):
     def get_all_args(self, ns=""):
         req = MatchRequest(db="CONFIG_DB", table="ACL_RULE", key_pattern="*", ns=ns)
         ret = self.match_engine.fetch(req)
-        acl_rules = ret["keys"]
-        return [key.split(CFG_DB_SEPARATOR, 1)[-1] for key in acl_rules]
+        req_app = MatchRequest(db="APPL_DB", table=APP_RULE_NAME, key_pattern="*", ns=ns)
+        ret_app = self.match_engine.fetch(req_app)
+        return [f"{CFG_DB_SEPARATOR}".join(key.split(CFG_DB_SEPARATOR)[1:]) for key in ret.get("keys")] + \
+                [f"{APP_DB_SEPARATOR}".join(key.split(APP_DB_SEPARATOR)[1:]) for key in ret_app.get("keys")]
 
     def execute(self, params):
-        self.ret_temp = create_template_dict(dbs=["CONFIG_DB", "ASIC_DB"])
-
+        self.ret_temp = create_template_dict(dbs=["CONFIG_DB", "APPL_DB", "ASIC_DB"])
+        invalid = False
         try:
             acl_table_name, acl_rule_name = params[self.ARG_NAME].split(CFG_DB_SEPARATOR, 1)
         except ValueError:
-            raise ValueError(f"Invalid rule name passed {params[self.ARG_NAME]}")
+            invalid = True
+
+        if invalid:
+            try:
+                acl_table_name, acl_rule_name = params[self.ARG_NAME].split(APP_DB_SEPARATOR, 1)
+            except ValueError:
+                raise ValueError(f"Invalid rule name passed {params[self.ARG_NAME]}")
 
         self.ns = params["namespace"]
         self.init_acl_rule_config_info(acl_table_name, acl_rule_name)
+        self.init_acl_rule_appl_info(acl_table_name, acl_rule_name)
         self.init_acl_rule_asic_info(acl_table_name, acl_rule_name)
         return self.ret_temp
 
@@ -42,7 +53,15 @@ class Acl_Rule(Executor):
         req = MatchRequest(db="CONFIG_DB", table="ACL_RULE",
                            key_pattern=CFG_DB_SEPARATOR.join([acl_table_name, acl_rule_name]), ns=self.ns)
         ret = self.match_engine.fetch(req)
-        self.add_to_ret_template(req.table, req.db, ret["keys"], ret["error"])
+        if ret["keys"]:
+            self.add_to_ret_template(req.table, req.db, ret["keys"], ret["error"])
+
+    def init_acl_rule_appl_info(self, acl_table_name, acl_rule_name):
+        req = MatchRequest(db="APPL_DB", table=APP_RULE_NAME,
+                           key_pattern=APP_DB_SEPARATOR.join([acl_table_name, acl_rule_name]), ns=self.ns)
+        ret = self.match_engine.fetch(req)
+        if ret["keys"]:
+            self.add_to_ret_template(req.table, req.db, ret["keys"], ret["error"])
 
     def init_acl_rule_asic_info(self, acl_table_name, acl_rule_name):
         counter_oid = fetch_acl_counter_oid(self.match_engine, acl_table_name, acl_rule_name, self.ns)

--- a/dump/plugins/acl_table.py
+++ b/dump/plugins/acl_table.py
@@ -8,6 +8,10 @@ from .executor import Executor
 
 CFG_DB_SEPARATOR = SonicDBConfig.getSeparator("CONFIG_DB")
 ASIC_DB_SEPARATOR = SonicDBConfig.getSeparator("ASIC_DB")
+APP_DB_SEPARATOR = SonicDBConfig.getSeparator("APPL_DB")
+APP_TABLE_TYPE_NAME = "ACL_TABLE_TYPE_TABLE"
+APP_TABLE_NAME = "ACL_TABLE_TABLE"
+APP_RULE_NAME = "ACL_RULE_TABLE"
 
 
 class Acl_Table(Executor):
@@ -22,21 +26,25 @@ class Acl_Table(Executor):
     def get_all_args(self, ns=""):
         req = MatchRequest(db="CONFIG_DB", table="ACL_TABLE", key_pattern="*", ns=ns)
         ret = self.match_engine.fetch(req)
-        acl_tables = ret["keys"]
-        return [key.split(CFG_DB_SEPARATOR)[-1] for key in acl_tables]
+        req_app = MatchRequest(db="APPL_DB", table=APP_TABLE_NAME, key_pattern="*", ns=ns)
+        ret_app = self.match_engine.fetch(req_app)
+        return [key.split(CFG_DB_SEPARATOR)[-1] for key in ret.get("keys")] + \
+                [key.split(APP_DB_SEPARATOR)[-1] for key in ret_app.get("keys")]
 
     def execute(self, params):
-        self.ret_temp = create_template_dict(dbs=["CONFIG_DB", "ASIC_DB"])
+        self.ret_temp = create_template_dict(dbs=["CONFIG_DB", "APPL_DB", "ASIC_DB"])
         acl_table_name = params[self.ARG_NAME]
         self.ns = params["namespace"]
         self.init_acl_table_config_info(acl_table_name)
+        self.init_acl_table_appl_info(acl_table_name)
         self.init_acl_table_asic_info(acl_table_name)
         return self.ret_temp
 
     def init_acl_table_config_info(self, acl_table_name):
         req = MatchRequest(db="CONFIG_DB", table="ACL_TABLE", key_pattern=acl_table_name, return_fields=["type"], ns=self.ns)
         ret = self.match_engine.fetch(req)
-        self.add_to_ret_template(req.table, req.db, ret["keys"], ret["error"])
+        if ret["keys"]:
+            self.add_to_ret_template(req.table, req.db, ret["keys"], ret["error"])
 
         # Find corresponding ACL table type in CONFIG DB
         return_values = ret["return_values"]
@@ -47,13 +55,39 @@ class Acl_Table(Executor):
         if ret["keys"]:
             self.add_to_ret_template(req.table, req.db, ret["keys"], ret["error"])
 
-    def init_acl_table_asic_info(self, acl_table_name):
+    def init_acl_table_appl_info(self, acl_table_name):
+        req = MatchRequest(db="APPL_DB", table=APP_TABLE_NAME, key_pattern=acl_table_name, return_fields=["type"], ns=self.ns)
+        ret = self.match_engine.fetch(req)
+        if ret["keys"]:
+            self.add_to_ret_template(req.table, req.db, ret["keys"], ret["error"])
+
+        # Find corresponding ACL table type in CONFIG DB
+        return_values = ret["return_values"]
+        acl_table_type_name = return_values.get(APP_DB_SEPARATOR.join([APP_TABLE_NAME, acl_table_name]), {}).get("type")
+        req = MatchRequest(db="APPL_DB", table=APP_TABLE_TYPE_NAME, key_pattern=acl_table_type_name, ns=self.ns)
+        ret = self.match_engine.fetch(req)
+        # If not found don't add it to the table, it might be a default table type
+        if ret["keys"]:
+            self.add_to_ret_template(req.table, req.db, ret["keys"], ret["error"])
+
+    def find_any_rule(self, acl_table_name):
         req = MatchRequest(db="CONFIG_DB", table="ACL_RULE", key_pattern=CFG_DB_SEPARATOR.join([acl_table_name, "*"]), ns=self.ns)
         ret = self.match_engine.fetch(req)
         acl_rules = ret["keys"]
-        if not acl_rules:
+        if acl_rules:
+            return acl_rules[0].split(CFG_DB_SEPARATOR)[-1]
+
+        # Check in APPL_DB
+        req = MatchRequest(db="APPL_DB", table=APP_RULE_NAME, key_pattern=APP_DB_SEPARATOR.join([acl_table_name, "*"]), ns=self.ns)
+        ret = self.match_engine.fetch(req)
+        acl_rules = ret["keys"]
+        if acl_rules:
+            return acl_rules[0].split(APP_DB_SEPARATOR)[-1]
+
+    def init_acl_table_asic_info(self, acl_table_name):
+        acl_rule_name = self.find_any_rule(acl_table_name)
+        if not acl_rule_name:
             return
-        acl_rule_name = acl_rules[0].split(CFG_DB_SEPARATOR)[-1]
 
         counter_oid = fetch_acl_counter_oid(self.match_engine, acl_table_name, acl_rule_name, self.ns)
         if not counter_oid:

--- a/tests/dump_input/acl/appl_db.json
+++ b/tests/dump_input/acl/appl_db.json
@@ -1,0 +1,18 @@
+{
+    "ACL_TABLE_TYPE_TABLE:MY_TYPE": {
+        "matches": "ETHER_TYPE,L4_DST_PORT_RANGE,L4_SRC_PORT_RANGE ",
+        "bind_point_types": "port"
+    },
+    "ACL_TABLE_TABLE:DATAACL2": {
+        "policy_desc": "Some ACL table",
+        "ports": "Ethernet0,Ethernet4",
+        "stage": "ingress",
+        "type": "MY_TYPE"
+    },
+    "ACL_RULE_TABLE:DATAACL2:R0": {
+        "L4_SRC_PORT_RANGE ": "90-95",
+        "L4_DST_PORT_RANGE ": "90-95",
+        "PACKET_ACTION": "FORWARD",
+        "PRIORITY": "999"
+    }
+}

--- a/tests/dump_input/acl/config_db.json
+++ b/tests/dump_input/acl/config_db.json
@@ -7,10 +7,6 @@
         "stage": "ingress",
         "type": "CTRLPLANE"
     },
-    "ACL_TABLE_TYPE|MY_TYPE": {
-        "matches": "ETHER_TYPE,L4_DST_PORT_RANGE,L4_SRC_PORT_RANGE ",
-        "bind_point_types": "port"
-    },
     "ACL_TABLE|DATAACL": {
         "policy_desc": "Some ACL table",
         "ports": "Ethernet0,Ethernet4",
@@ -23,20 +19,8 @@
         "stage": "ingress",
         "type": "L3"
     },
-    "ACL_TABLE|DATAACL2": {
-        "policy_desc": "Some ACL table",
-        "ports": "Ethernet0,Ethernet4",
-        "stage": "ingress",
-        "type": "MY_TYPE"
-    },
     "ACL_RULE|DATAACL|R0": {
         "ETHER_TYPE": "2048",
-        "PACKET_ACTION": "FORWARD",
-        "PRIORITY": "999"
-    },
-    "ACL_RULE|DATAACL2|R0": {
-        "L4_SRC_PORT_RANGE ": "90-95",
-        "L4_DST_PORT_RANGE ": "90-95",
         "PACKET_ACTION": "FORWARD",
         "PRIORITY": "999"
     }

--- a/tests/dump_tests/module_tests/acl_test.py
+++ b/tests/dump_tests/module_tests/acl_test.py
@@ -18,6 +18,7 @@ port_files_path = os.path.join(dump_test_input, "acl")
 # Define the mock files to read from
 dedicated_dbs = {}
 dedicated_dbs['CONFIG_DB'] = os.path.join(port_files_path, "config_db.json")
+dedicated_dbs['APPL_DB'] = os.path.join(port_files_path, "appl_db.json")
 dedicated_dbs['COUNTERS_DB'] = os.path.join(port_files_path, "counters_db.json")
 dedicated_dbs['ASIC_DB'] = os.path.join(port_files_path, "asic_db.json")
 
@@ -56,7 +57,7 @@ class TestAclTableModule:
         params = {Acl_Table.ARG_NAME: "DATAACL", "namespace": ""}
         m_acl_table = Acl_Table(match_engine)
         returned = m_acl_table.execute(params)
-        expect = create_template_dict(dbs=["CONFIG_DB", "ASIC_DB"])
+        expect = create_template_dict(dbs=["CONFIG_DB", "APPL_DB", "ASIC_DB"])
         expect["CONFIG_DB"]["keys"].append("ACL_TABLE|DATAACL")
         expect["ASIC_DB"]["keys"].append("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE:oid:0x7000000000600")
         expect["ASIC_DB"]["keys"].append("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP_MEMBER:oid:0xc000000000601")
@@ -73,7 +74,7 @@ class TestAclTableModule:
         params = {Acl_Table.ARG_NAME: "DATAACL1", "namespace": ""}
         m_acl_table = Acl_Table(match_engine)
         returned = m_acl_table.execute(params)
-        expect = create_template_dict(dbs=["CONFIG_DB", "ASIC_DB"])
+        expect = create_template_dict(dbs=["CONFIG_DB", "APPL_DB", "ASIC_DB"])
         expect["CONFIG_DB"]["keys"].append("ACL_TABLE|DATAACL1")
         ddiff = DeepDiff(sort_lists(returned), sort_lists(expect))
         assert not ddiff, ddiff
@@ -85,9 +86,9 @@ class TestAclTableModule:
         params = {Acl_Table.ARG_NAME: "DATAACL2", "namespace": ""}
         m_acl_table = Acl_Table(match_engine)
         returned = m_acl_table.execute(params)
-        expect = create_template_dict(dbs=["CONFIG_DB", "ASIC_DB"])
-        expect["CONFIG_DB"]["keys"].append("ACL_TABLE|DATAACL2")
-        expect["CONFIG_DB"]["keys"].append("ACL_TABLE_TYPE|MY_TYPE")
+        expect = create_template_dict(dbs=["CONFIG_DB", "APPL_DB", "ASIC_DB"])
+        expect["APPL_DB"]["keys"].append("ACL_TABLE_TABLE:DATAACL2")
+        expect["APPL_DB"]["keys"].append("ACL_TABLE_TYPE_TABLE:MY_TYPE")
         expect["ASIC_DB"]["keys"].append("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE:oid:0x7100000000600")
         expect["ASIC_DB"]["keys"].append("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP_MEMBER:oid:0xc100000000601")
         expect["ASIC_DB"]["keys"].append("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP_MEMBER:oid:0xc100000000602")
@@ -95,6 +96,17 @@ class TestAclTableModule:
         expect["ASIC_DB"]["keys"].append("ASIC_STATE:SAI_OBJECT_TYPE_ACL_TABLE_GROUP:oid:0xb0000000005f7")
         ddiff = DeepDiff(sort_lists(returned), sort_lists(expect))
         assert not ddiff, ddiff
+
+    def test_all_arg(self, match_engine):
+        """
+        Scenario: Test if all arg returns from config_db and appl_db
+        """
+        m_acl_table = Acl_Table(match_engine)
+        returned = m_acl_table.get_all_args()
+        returned.sort()
+        expected = ['DATAACL', 'DATAACL1', 'DATAACL2', 'SNMP_ACL']
+        assert returned == expected, returned
+
 
 @pytest.mark.usefixtures("match_engine")
 class TestAclRuleModule:
@@ -105,7 +117,7 @@ class TestAclRuleModule:
         params = {Acl_Rule.ARG_NAME: "DATAACL|R0", "namespace": ""}
         m_acl_rule = Acl_Rule(match_engine)
         returned = m_acl_rule.execute(params)
-        expect = create_template_dict(dbs=["CONFIG_DB", "ASIC_DB"])
+        expect = create_template_dict(dbs=["CONFIG_DB", "APPL_DB", "ASIC_DB"])
         expect["CONFIG_DB"]["keys"].append("ACL_RULE|DATAACL|R0")
         expect["ASIC_DB"]["keys"].append("ASIC_STATE:SAI_OBJECT_TYPE_ACL_COUNTER:oid:0x9000000000606")
         expect["ASIC_DB"]["keys"].append("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY:oid:0x8000000000609")
@@ -119,11 +131,21 @@ class TestAclRuleModule:
         params = {Acl_Rule.ARG_NAME: "DATAACL2|R0", "namespace": ""}
         m_acl_rule = Acl_Rule(match_engine)
         returned = m_acl_rule.execute(params)
-        expect = create_template_dict(dbs=["CONFIG_DB", "ASIC_DB"])
-        expect["CONFIG_DB"]["keys"].append("ACL_RULE|DATAACL2|R0")
+        expect = create_template_dict(dbs=["CONFIG_DB", "APPL_DB", "ASIC_DB"])
+        expect["APPL_DB"]["keys"].append("ACL_RULE_TABLE:DATAACL2:R0")
         expect["ASIC_DB"]["keys"].append("ASIC_STATE:SAI_OBJECT_TYPE_ACL_COUNTER:oid:0x9100000000606")
         expect["ASIC_DB"]["keys"].append("ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY:oid:0x8100000000609")
         expect["ASIC_DB"]["keys"].append("ASIC_STATE:SAI_OBJECT_TYPE_ACL_RANGE:oid:0xa100000000607")
         expect["ASIC_DB"]["keys"].append("ASIC_STATE:SAI_OBJECT_TYPE_ACL_RANGE:oid:0xa100000000608")
         ddiff = DeepDiff(sort_lists(returned), sort_lists(expect))
         assert not ddiff, ddiff
+
+    def test_all_arg(self, match_engine):
+        """
+        Scenario: Test if all arg returns from config_db and appl_db
+        """
+        m_acl_rule = Acl_Rule(match_engine)
+        returned = m_acl_rule.get_all_args()
+        returned.sort()
+        expected = ['DATAACL2:R0', 'DATAACL|R0']
+        assert returned == expected, returned

--- a/tests/mock_tables/appl_db.json
+++ b/tests/mock_tables/appl_db.json
@@ -409,5 +409,24 @@
         "action": "set_vrf",
         "param/vrf_id": "p4rt-vrf-80",
         "controller_metadata": "my metadata"
+    },
+    "ACL_TABLE_TABLE:ENI": {
+          "PORTS": "Ethernet104,PortChannel108",
+          "STAGE": "INGRESS",
+          "TYPE": "ENI_REDIRECT",
+          "POLICY_DESC": "Contains Mock Rules for ENI Based Forwarding"
+    },
+    "ACL_RULE_TABLE:ENI:Vnet100_F4939FEFC47E_IN": {
+        "PRIORITY": "9996",
+        "DST_IP": "10.2.0.1/32",
+        "INNER_DST_MAC": "f4:93:9f:ef:c4:7e",
+        "REDIRECT_ACTION": "10.0.0.75"
+    },
+    "ACL_RULE_TABLE:ENI:Vnet100_F4939FEFC47E_OUT": {
+        "PRIORITY": "9997",
+        "DST_IP": "10.2.0.1/32",
+        "INNER_SRC_MAC": "f4:93:9f:ef:c4:7e",
+        "REDIRECT_ACTION": "10.0.0.75",
+        "TUNNEL_VNI": "4321"
     }
 }

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -1617,7 +1617,13 @@
     "ACL_TABLE_TABLE|DATAACL_5" : {
         "status": "Active"
     },
+    "ACL_TABLE_TABLE|ENI" : {
+        "status": "Active"
+    },
     "ACL_RULE_TABLE|DATAACL_5|RULE_1" : {
+        "status": "Active"
+    },
+    "ACL_RULE_TABLE|ENI|Vnet100_F4939FEFC47E_OUT" : {
         "status": "Active"
     },
     "VOLTAGE_INFO|VSENSOR0": {

--- a/tests/show_acl_test.py
+++ b/tests/show_acl_test.py
@@ -17,6 +17,23 @@ DATAACL_5  L3      Ethernet20   DATAACL_5      ingress  {'asic0': 'Active', 'asi
                    Ethernet124
 """
 
+APPL_DB_ACL_SHOW_TABLE = """\
+Name    Type          Binding         Description                                   Stage    Status
+------  ------------  --------------  --------------------------------------------  -------  --------
+ENI     ENI_REDIRECT  Ethernet104     Contains Mock Rules for ENI Based Forwarding  ingress  Active
+                      PortChannel108
+"""
+
+APPL_DB_ACL_SHOW_RULE = """\
+Table    Rule                      Priority    Action               Match                             Status
+-------  ------------------------  ----------  -------------------  --------------------------------  --------
+ENI      Vnet100_F4939FEFC47E_OUT  9997        REDIRECT: 10.0.0.75  DST_IP: 10.2.0.1/32               Active
+                                                                    INNER_SRC_MAC: f4:93:9f:ef:c4:7e
+                                                                    TUNNEL_VNI: 4321
+ENI      Vnet100_F4939FEFC47E_IN   9996        REDIRECT: 10.0.0.75  DST_IP: 10.2.0.1/32               N/A
+                                                                    INNER_DST_MAC: f4:93:9f:ef:c4:7e
+"""
+
 @pytest.fixture()
 def setup_teardown_single_asic():
     os.environ["PATH"] += os.pathsep + scripts_path
@@ -93,5 +110,28 @@ class TestShowACLMultiASIC(object):
         result_top = result.output.split('\n')[2]
         expected_output = "DATAACL_5  RULE_1        9999  FORWARD   IP_PROTOCOL: 126  {'asic0': 'Active', 'asic2': 'Active'}"
         assert result_top == expected_output
-        
-        
+
+
+class TestShowACLApplDb(object):
+
+    def test_show_acl_table(self, setup_teardown_single_asic):
+        runner = CliRunner()
+        aclloader = AclLoader()
+        context = {
+            "acl_loader": aclloader
+        }
+        result = runner.invoke(acl_loader_show.cli.commands['show'].commands['table'], ["ENI"], obj=context)
+        assert result.exit_code == 0
+        print(result.output)
+        assert result.output == APPL_DB_ACL_SHOW_TABLE
+
+    def test_show_acl_rule(self, setup_teardown_single_asic):
+        runner = CliRunner()
+        aclloader = AclLoader()
+        context = {
+            "acl_loader": aclloader
+        }
+        result = runner.invoke(acl_loader_show.cli.commands['show'].commands['rule'], ["ENI"], obj=context)
+        assert result.exit_code == 0
+        print(result.output)
+        assert result.output == APPL_DB_ACL_SHOW_RULE


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

Currently, show and dump CLI only show entries from CONFIG_DB. A lot of new features write ACL Rules to APPL_DB. Thus it is imperative that the CLI's should be updated to display ACL tables and rules from APPL_DB

#### How I did it

#### How to verify it

1) UT's
2) Manual Testing by writing ACL rules to APPL_DB

**ACl rules written to APPL_DB**
```
root@sonic:/home/admin# sonic-db-cli APPL_DB KEYS "*ENI*"
ACL_TABLE_TYPE_TABLE:ENI_REDIRECT
ACL_RULE_TABLE:ENI:Vnet100_F4939FEFC47E_OUT
ACL_TABLE_TABLE:ENI
ACL_RULE_TABLE:ENI:Vnet100_F4939FEFC47E_IN
```

**Show CLI**
```
root@sonic/home/admin# show acl table ENI
Name    Type          Binding      Description                                  Stage    Status
------  ------------  -----------  -------------------------------------------  -------  --------
ENI     ENI_REDIRECT  Ethernet64   Contains Rule for DASH ENI Based Forwarding  ingress  Active
                      Ethernet72
                      Ethernet104
                      Ethernet112
                      Ethernet120
                      Ethernet128
                      Ethernet136
                      Ethernet144
                      Ethernet152
                      Ethernet160
                      Ethernet168
                      Ethernet176
                      Ethernet184
                      Ethernet192
                      Ethernet200
                      Ethernet208
                      Ethernet216

root@sonic:/home/admin# show acl rule
Table    Rule                      Priority    Action              Match                Status
-------  ------------------------  ----------  ------------------  -------------------  --------
ENI      Vnet100_F4939FEFC47E_OUT  9997        REDIRECT: 10.0.0.1  DST_IP: 10.2.0.1/32  Active
                                                                   TUNNEL_VNI: 4321
ENI      Vnet100_F4939FEFC47E_IN   9996        REDIRECT: 10.0.0.1  DST_IP: 10.2.0.1/32  Active
```

**Dump CLI**
```
root@sonic:/home/admin# dump state acl_rule ENI:Vnet100_F4939FEFC47E_IN --key-map
{
    "ENI:Vnet100_F4939FEFC47E_IN": {
        "CONFIG_DB": {
            "keys": [],
            "tables_not_found": []
        },
        "APPL_DB": {
            "keys": [
                "ACL_RULE_TABLE:ENI:Vnet100_F4939FEFC47E_IN"
            ],
            "tables_not_found": []
        },
        "ASIC_DB": {
            "keys": [
                "ASIC_STATE:SAI_OBJECT_TYPE_ACL_COUNTER:oid:0x9000000000694",
                "ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY:oid:0x8000000000695",
                "ASIC_STATE:SAI_OBJECT_TYPE_ACL_ENTRY:oid:0x8000000000697"
            ],
            "tables_not_found": [],
            "vidtorid": {
                "oid:0x9000000000694": "oid:0x381ff000f0009",
                "oid:0x8000000000695": "oid:0x30008",
                "oid:0x8000000000697": "oid:0x100030008"
            }
        }
    }
}
```

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

